### PR TITLE
Tracking (GA) clicks on Slack and Cilium links

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -15,7 +15,8 @@ module.exports = {
       resolve: `gatsby-plugin-google-analytics`,
       options: {
         trackingId: "UA-96283704-3",
-        head: false
+        head: false,
+        pageTransitionDelay: 0
       }
     },
     {

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -25,11 +25,11 @@ const HeaderDesktop = () => (
     <nav className="headerNav">
       <Link to="/what-is-ebpf">What is eBPF?</Link>
       <Link to="/projects">Projects</Link>
-      <a href="https://cilium.herokuapp.com/">Slack</a>
+      <Link to="/slack">Slack</Link>
       <Link to="/contribute">Contribute</Link>
-      <a href="https://www.cilium.io">
+      <Link to="/enterprise">
         <img src={require("../assets/cilium_logo.png")} height="50px" />
-      </a>
+      </Link>
     </nav>
   </div>
 );
@@ -65,11 +65,11 @@ class HeaderMobile extends React.Component {
           <nav className="headerNav">
             <Link to="/what-is-ebpf">What is eBPF?</Link>
             <Link to="/projects">Projects</Link>
-            <a href="https://cilium.herokuapp.com/">Slack</a>
+            <Link to="/slack">Slack</Link>
             <Link to="/contribute">Contribute</Link>
-            <a href="https://www.cilium.io">
+            <Link to="/enterprise">
               <img src={require("../assets/cilium_logo.png")} height="50px" />
-            </a>
+            </Link>
           </nav>
         )}
       </div>

--- a/src/pages/contribute.js
+++ b/src/pages/contribute.js
@@ -1,4 +1,5 @@
 import Helmet from "react-helmet";
+import Link from "gatsby-link";
 import Layout from "../layouts";
 import React from "react";
 
@@ -79,7 +80,6 @@ const Page = () => (
         You will find information on how to get involved on each project website
         directly.
       </p>
-
       <h2>Contribute to ebpf.io</h2>
       <p>
         Do you have a writing talent? Are you good with diagrams? The content of the
@@ -87,12 +87,10 @@ const Page = () => (
         href="https://creativecommons.org/licenses/by/4.0/">Creative Commons
         Attribution 4.0 International License</a>. If you want to get involved,
         visit the <a href="https://github.com/cilium/ebpf.io">GitHub
-        repository</a>.  Make sure to also join the <a
-        href="https://cilium.herokuapp.com/">#ebpf Slack channel</a> to get in
+        repository</a>.  Make sure to also join the <Link to="/slack">#ebpf Slack channel</Link> to get in
         touch with the team working on the documentation.  Share what you have
         learned by improving the documentation or write additional tutorials.
       </p>
-
     </div>
   </Layout>
 );

--- a/src/pages/enterprise.js
+++ b/src/pages/enterprise.js
@@ -1,0 +1,19 @@
+import React, { useEffect } from "react";
+import Helmet from "react-helmet";
+
+const Page = () => {
+  useEffect(() => {
+    setTimeout(
+      () => window.location.href = "https://www.cilium.io",
+      500
+    );
+  }, []);
+  return (
+    <div>
+      <Helmet title="eBPF / Enterprise" />
+      <h1 className="page-note">Please wait...</h1>
+    </div>
+  );
+}
+
+export default Page;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -208,9 +208,9 @@ const Outro = () => (
           <td>
             <ul>
               <li>
-                <a href="https://cilium.herokuapp.com/">
+                <Link to="/slack">
                   Join the #ebpf Slack community
-                </a>
+                </Link>
               </li>
               <li>
                 <a href="/contribute">Learn how to contribute</a>

--- a/src/pages/projects.js
+++ b/src/pages/projects.js
@@ -1,4 +1,5 @@
 import Helmet from "react-helmet";
+import Link from "gatsby-link";
 import Layout from "../layouts";
 import React from "react";
 
@@ -9,7 +10,7 @@ const YouMaintain = () => (
     <li>
       If you are maintaining one of the listed projects and would like to adjust
       the content. Get in touch on{" "}
-      <a href="https://cilium.herokuapp.com/">Slack</a> or open a pull request
+      <Link to="/slack">Slack</Link> or open a pull request
       directly.
     </li>
   </ul>
@@ -29,7 +30,7 @@ const HowToList = () => (
     <li>
       The pull request will be reviewed by the community and merged by one of
       the maintainers. If you have any questions, feel free to ask on{" "}
-      <a href="https://cilium.herokuapp.com/">Slack</a>.
+      <Link to="/slack">Slack</Link>.
     </li>
   </ol>
 );
@@ -147,9 +148,9 @@ const ProjectDescriptions = () => (
         </a>
         <div className="project-description">
           <p>
-            <a href="https://cilium.io">
+            <Link to="/enterprise">
               <b>Website</b>
-            </a>{" "}
+            </Link>{" "}
             |{" "}
             <a href="https://github.com/cilium/cilium">
               <b>GitHub</b>
@@ -424,9 +425,9 @@ const ProjectDescriptions = () => (
         </a>
         <div className="project-description">
           <p>
-            <a href="https://cilium.io/">
+            <Link to="/enterprise">
               <b>Website</b>
-            </a>{" "}
+            </Link>{" "}
             |{" "}
             <a href="https://github.com/cilium/hubble">
               <b>GitHub</b>

--- a/src/pages/slack.js
+++ b/src/pages/slack.js
@@ -1,0 +1,19 @@
+import React, { useEffect } from "react";
+import Helmet from "react-helmet";
+
+const Page = () => {
+  useEffect(() => {
+    setTimeout(
+      () => window.location.href = "https://cilium.herokuapp.com/",
+      500
+    );
+  }, []);
+  return (
+    <div>
+      <Helmet title="eBPF / Slack" />
+      <h1 className="page-note">Please wait...</h1>
+    </div>
+  );
+}
+
+export default Page;

--- a/src/pages/what-is-ebpf.js
+++ b/src/pages/what-is-ebpf.js
@@ -617,6 +617,11 @@ class Description extends React.Component {
           <h4>Cilium</h4>
           <ul>
             <Reference
+              link="https://linuxplumbersconf.org/event/7/contributions/674/"
+              name="Kubernetes Service Load-Balancing at Scale with BPF & XDP"
+              description="Daniel Borkmann & Martynas Pumputis, Linux Plumbers, Aug 2020"
+            />
+            <Reference
               link="https://www.youtube.com/watch?v=bIRwSIwNHC0"
               slides="https://docs.google.com/presentation/d/1cZJ-pcwB9WG88wzhDm2jxQY4Sh8adYg0-N3qWQ8593I/edit#slide=id.g7055f48ba8_0_0"
               name="Liberating Kubernetes from kube-proxy and iptables"

--- a/src/pages/what-is-ebpf.js
+++ b/src/pages/what-is-ebpf.js
@@ -617,11 +617,6 @@ class Description extends React.Component {
           <h4>Cilium</h4>
           <ul>
             <Reference
-              link="https://linuxplumbersconf.org/event/7/contributions/674/"
-              name="Kubernetes Service Load-Balancing at Scale with BPF & XDP"
-              description="Daniel Borkmann & Martynas Pumputis, Linux Plumbers, Aug 2020"
-            />
-	    <Reference
               link="https://www.youtube.com/watch?v=bIRwSIwNHC0"
               slides="https://docs.google.com/presentation/d/1cZJ-pcwB9WG88wzhDm2jxQY4Sh8adYg0-N3qWQ8593I/edit#slide=id.g7055f48ba8_0_0"
               name="Liberating Kubernetes from kube-proxy and iptables"

--- a/src/stylesheets/index.scss
+++ b/src/stylesheets/index.scss
@@ -73,6 +73,12 @@ code {
   font-size: 14px;
 }
 
+.page-note {
+  font-size: 16px;
+  text-align: center;
+  margin: 10% 0;
+}
+
 .introDisclaimer {
   width: 100%;
   box-sizing: border-box;


### PR DESCRIPTION
Introduce two pages with redirects to Slack and Cilium in order to track the clicks in GA Behavour Flow section. Buttons clicks can also be tracked using GA Events, but in this case Behaviour Flow graph will not be updated:
<img width="271" alt="image" src="https://user-images.githubusercontent.com/58164/91309899-7cf6d400-e7b1-11ea-8f18-a834d50b00fa.png">
