### PR TITLE
Verbose pages titles

### DIFF
--- a/src/pages/contribute.js
+++ b/src/pages/contribute.js
@@ -21,7 +21,7 @@ const Section = ({
 const Page = () => (
   <Layout>
     <div className="page-wrapper page-contribute">
-      <Helmet title="eBPF / Contribute" />
+      <Helmet title="How to contribute to eBPF?" />
       <Title />
       <p>
         eBPF consists of many communities including the eBPF runtime in the Linux

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,3 +1,4 @@
+import Helmet from "react-helmet";
 import React from "react";
 import Layout from "../layouts";
 import { Link } from "gatsby";
@@ -347,6 +348,7 @@ class BlogRoll extends React.Component {
 const IndexPage = () => (
   <Layout>
     <div className="page-wrapper page-index">
+      <Helmet title="eBPF - Introduction & Community Resources" />
       <Title />
       <Buttons />
       <Intro />

--- a/src/pages/projects.js
+++ b/src/pages/projects.js
@@ -514,7 +514,7 @@ const ProjectDescriptions = () => (
 const Page = () => (
   <Layout>
     <div className="page-wrapper page-projects">
-      <Helmet title="eBPF / Projects" />
+      <Helmet title="eBPF - List of projects using eBPF" />
       <ProjectDescriptions />
       <div className="projects-title">FAQ</div>
       <h3>Add your project</h3>

--- a/src/pages/what-is-ebpf.js
+++ b/src/pages/what-is-ebpf.js
@@ -621,7 +621,7 @@ class Description extends React.Component {
               name="Kubernetes Service Load-Balancing at Scale with BPF & XDP"
               description="Daniel Borkmann & Martynas Pumputis, Linux Plumbers, Aug 2020"
             />
-	    <Reference
+            <Reference
               link="https://www.youtube.com/watch?v=bIRwSIwNHC0"
               slides="https://docs.google.com/presentation/d/1cZJ-pcwB9WG88wzhDm2jxQY4Sh8adYg0-N3qWQ8593I/edit#slide=id.g7055f48ba8_0_0"
               name="Liberating Kubernetes from kube-proxy and iptables"
@@ -741,7 +741,7 @@ const Section = ({ icon, iconWidth, iconHeight, title, text, style }) => (
 const Page = () => (
   <Layout>
     <div className="page-wrapper page-what-is-ebpf">
-      <Helmet title="eBPF / What is eBPF" />
+      <Helmet title="What is eBPF? An Introduction and Deep Dive into the eBPF Technology" />
       <Description />
     </div>
   </Layout>


### PR DESCRIPTION
* Introduces more verbose pages titles
* The empty `.eslintrc` was added as a way to [disable Gatsby's default eslint settings](https://www.gatsbyjs.com/docs/eslint/#disabling-eslint).