### PR TITLE
Fix patchwork URL for kernel patches

### DIFF
--- a/src/pages/projects.js
+++ b/src/pages/projects.js
@@ -266,7 +266,7 @@ const ProjectDescriptions = () => (
               <b>Mailing List</b>
             </a>{" "}
             |{" "}
-            <a href="https://patchwork.ozlabs.org/project/netdev/list/?series=&submitter=&state=&q=&archive=&delegate=77147">
+            <a href="https://patchwork.kernel.org/project/netdevbpf/list/?delegate=121173">
               <b>Patches</b>
             </a>{" "}
             |{" "}


### PR DESCRIPTION
We moved from ozlabs to kernel.org some time ago.

Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>