### PR TITLE
Filter pchaigno.github.io's posts by category

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -260,7 +260,10 @@ class BlogRoll extends React.Component {
     {
       url: "https%3A%2F%2Fpchaigno.github.io%2Ffeed.xml",
       author: "Paul Chaignon",
-      filterBy: (post) => post.title.toLowerCase().includes("bpf"),
+      filterBy: (post) =>
+        post.categories.some((category) =>
+          category.toLowerCase().includes("bpf")
+        ),
     },
     {
       url: "https%3A%2F%2Fnakryiko.com%2Fatom.xml",


### PR DESCRIPTION
We only want to display blog posts related to eBPF. The category should be a better reflection of that than the title since I have an `ebpf` category.