### PR TITLE
ebpf_updates: extend title for first issue, fix date of publication

### DIFF
--- a/src/posts/2020-11-20-ebpf-updates/index.md
+++ b/src/posts/2020-11-20-ebpf-updates/index.md
@@ -1,7 +1,7 @@
 ---
 path: "/news/ebpf-updates-intro"
-date: "2020-11-19T10:00:00.000Z"
-title: "eBPF Updates #1"
+date: "2020-11-20T10:00:00.000Z"
+title: "eBPF Updates #1: eBPF Summit Coverage, libbpf 0.2, BTF Developments, Bulk API for XDP, Local Task Storage for eBPF LSM"
 tags:
   - _
 categories:


### PR DESCRIPTION
Instead of simply `eBPF Updates #1`, append the main information items to the title of the page. This will make the title more attractive and should readers better identify the information they might be looking for when browsing the list of posts.

Also fix the date of publication.