### PR TITLE
Add a permanent redirect after renaming News > Blog

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,0 +1,1 @@
+/news/rss.xml /blog/rss.xml


### PR DESCRIPTION
Adds a redirect instruction in the Netlify config file.