### PR TITLE
Add French translation for homepage

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -62,8 +62,10 @@ exports.createSchemaCustomization = ({ actions }) => {
 exports.createPages = ({ actions, graphql }) => {
   const { createPage, createRedirect } = actions;
   // "Country" must start with a capital letter
+  createRedirect({ fromPath: '/', force: true, toPath: '/fr-fr/', Country: 'fr' });
   createRedirect({ fromPath: '/', force: true, toPath: '/zh-cn/', Country: 'cn' });
   // "Language" must start with a capital letter
+  createRedirect({ fromPath: '/', force: true, toPath: '/fr-fr/', Language: 'fr' });
   createRedirect({ fromPath: '/', force: true, toPath: '/zh-cn/', Language: 'zh' });
   const postTemplate = path.resolve(`src/templates/post.js`);
 

--- a/src/common/homepage/BlogLatest.js
+++ b/src/common/homepage/BlogLatest.js
@@ -1,0 +1,12 @@
+import React from "react";
+import { Post } from "../../templates/post";
+import { TitleWithAnchor } from "../TitleWithAnchor";
+
+export default function ({title, posts}) {
+  return <div className="blog-latest">
+    <TitleWithAnchor className="common-title-container" headerClassName="common-title" children={title} />
+    <div className="blog-posts">
+      {posts.map(({node: post}) => <Post key={post.id} post={post} />)}
+    </div>
+  </div>
+};

--- a/src/common/homepage/BlogRoll.js
+++ b/src/common/homepage/BlogRoll.js
@@ -1,0 +1,157 @@
+import React from "react";
+import stringSimilarity from "string-similarity";
+import { unescape } from "lodash";
+import { format, parse as parseDate } from "date-fns";
+import { TitleWithAnchor } from "../TitleWithAnchor";
+
+export default class BlogRoll extends React.Component {
+  feeds = [
+    {
+      url: "http%3A%2F%2Fwww.brendangregg.com%2Fblog%2Frss.xml",
+      author: "Brendan Gregg",
+      filterBy: (post) => post.title.toLowerCase().includes("bpf"),
+    },
+    {
+      url:
+        "http%3A%2F%2Ffetchrss.com%2Frss%2F5f326ba08a93f8883b8b45675f326d238a93f8b34b8b4567.xml",
+      author: null,
+      filterBy: (post) =>
+        post.title.toLowerCase().includes("bpf") &&
+        post.link !==
+          "https://facebookmicrosites.github.io/bpf/blog/2018/08/31/welcome.html",
+    },
+    {
+      url: "https%3A%2F%2Fcilium.io%2Fblog%2Frss.xml",
+      author: "Cilium authors",
+      filterBy: (post) =>
+        post.categories.some((category) =>
+          category.toLowerCase().includes("announcements")
+        ),
+    },
+    {
+      url: "https%3A%2F%2Fqmonnet.github.io%2Fwhirl-offload%2Ffeed.xml",
+      author: "Quentin Monnet",
+      filterBy: (post) => post.title.toLowerCase().includes("bpf"),
+    },
+    {
+      url: "https%3A%2F%2Fpchaigno.github.io%2Ffeed.xml",
+      author: "Paul Chaignon",
+      filterBy: (post) => post.title.toLowerCase().includes("bpf"),
+    },
+    {
+      url: "https%3A%2F%2Fnakryiko.com%2Fatom.xml",
+      author: "Andrii Nakryiko",
+      filterBy: (post) => post.title.toLowerCase().includes("bpf") || post.title.toLowerCase().includes("btf"),
+    },
+  ];
+
+  constructor(props) {
+    super(props);
+
+    this.title = props.title;
+    this.state = {
+      posts: [],
+    };
+  }
+
+  componentDidMount() {
+    const apiUrl = "https://api.rss2json.com/v1/api.json";
+    const apiKey = process.env.RSS2JSON_API_KEY;
+    Promise.all(
+      this.feeds.map((feed) =>
+        fetch(`${apiUrl}?api_key=${apiKey}&rss_url=${feed.url}`)
+          .then((r) => r.json())
+          .then((post) => ({ feed, post }))
+      )
+    )
+      .then((results) => {
+        results.map((result) => {
+          if(result.post.status !== 'ok') {
+            console.error(`Feed ${result.post.feed.url} is temporary unavailable`)
+          }
+        });
+        return results
+          .filter((result) => result.post.status === 'ok')
+          .reduce((acc, { feed, post: { items } }) => {
+          return acc.concat(
+            items
+              .map((post) => ({
+                ...post,
+                pubDate: parseDate(
+                  post.pubDate,
+                  "yyyy-MM-dd HH:mm:ss",
+                  new Date()
+                ),
+                author: post.author || feed.author,
+              }))
+              .sort((a, b) => b.pubDate - a.pubDate)
+              .filter(
+                (post) =>
+                  feed.filterBy(post) && post.pubDate.getFullYear() >= 2018
+              )
+              .slice(0, 3)
+          );
+        }, []);
+      })
+      .then((posts) => {
+        let uniqPosts = posts;
+        posts.forEach((initialPost) => {
+          uniqPosts.forEach((resultPost, idx) => {
+            /*
+              If two posts have same author, come from different websites and have similar titles — remove the second
+              one. Website check is necessary in case of such posts like "eBPF Summit Day 1 Recap" and
+              "eBPF Summit Day 2 Recap". Because within a single website uniqueness is controlled manually by editors
+              and thus posts with similar titles are rarely added on occasion.
+            */
+            if(
+              (initialPost.author || '').toLowerCase() === (resultPost.author || '').toLowerCase() &&
+              new URL(initialPost.link).host !== new URL(resultPost.link).host &&
+              stringSimilarity.compareTwoStrings(initialPost.title, resultPost.title) >= 0.75
+            ) {
+              uniqPosts.splice(idx, 1)
+            }
+          });
+        });
+        uniqPosts.sort((a, b) => b.pubDate - a.pubDate);
+        return uniqPosts;
+      })
+      .then((posts) => {
+        this.setState({ posts });
+      })
+      .catch((error) => console.error(error));
+  }
+
+  render() {
+    return (
+      <div className="blog-roll-section">
+        <TitleWithAnchor  className="common-title-container" headerClassName="common-title" children={this.title} />
+        {this.state.posts.length === 0 && (
+          <div className="blog-roll-loading">Loading...</div>
+        )}
+        {this.state.posts.length > 0 && (
+          <ul>
+            {this.state.posts.map((post) => {
+              return (
+                <li key={post.link}>
+                  <a
+                    href={post.link}
+                    className="blog-roll-item"
+                    target="_blank"
+                  >
+                    <span className="blog-roll-date">
+                      {format(post.pubDate, "MMM d, yyyy")}
+                    </span>{" "}
+                    <span className="blog-roll-title">
+                      <u>{unescape(post.title)}</u>{" "}
+                      <span className="blog-roll-author">{post.author}</span>
+                    </span>
+                  </a>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    );
+  }
+};

--- a/src/common/homepage/Helmet.js
+++ b/src/common/homepage/Helmet.js
@@ -1,0 +1,25 @@
+import React from "react";
+import Helmet from "react-helmet";
+
+export default function () {
+  const pageMetaTitle = 'eBPF - Introduction, Tutorials & Community Resources'
+  const pageMetaDescription = 'eBPF is a revolutionary technology that can run sandboxed programs in the Linux kernel without changing kernel source code or loading a kernel module.'
+
+  return <Helmet
+    title={pageMetaTitle}
+
+    meta={[
+      {name: "keywords", content: "ebpf, bpf, xdp, introduction, tutorial, documentation, deep dive, community"},
+      {name: "type", property: "og:type", content: "website"},
+      {name: "url", property: "og:url", content: "https://ebpf.io/"},
+      {name: "title", property: "og:title", content: pageMetaTitle},
+      {name: "description", property: "og:description", content: pageMetaDescription},
+      {name: "image", property: "og:image", content: 'https://ebpf.io' + require("../../assets/ogimage.png")},
+      {name: "twitter:card", content: "summary_large_image"},
+      {name: "twitter:url", content: "https://ebpf.io/"},
+      {name: "twitter:title", content: pageMetaTitle},
+      {name: "twitter:description", content: pageMetaDescription},
+      {name: "twitter:image", content: 'https://ebpf.io' + require("../../assets/ogimage.png")},
+    ]}
+  />
+};

--- a/src/common/homepage/MainTitle.js
+++ b/src/common/homepage/MainTitle.js
@@ -1,0 +1,7 @@
+import React from "react";
+
+export default function () {
+  return <hgroup>
+    <img className="main-logo" src={require("../../assets/logo-big.png")} />
+  </hgroup>
+};

--- a/src/common/homepage/Section.js
+++ b/src/common/homepage/Section.js
@@ -1,0 +1,9 @@
+import React from "react";
+
+export default function ({ icon, iconWidth, iconHeight, title, text, ...props }) {
+  return <div className="main-section" {...props}>
+    <div className="main-section-title">{title}</div>
+    <img className="section-logo" src={icon} width={iconWidth} />
+    <div className="main-section-text">{text}</div>
+  </div>
+};

--- a/src/common/homepage/Videos.js
+++ b/src/common/homepage/Videos.js
@@ -1,0 +1,67 @@
+import React from "react";
+import { shuffle } from "lodash";
+import Slider from "infinite-react-carousel";
+import { TitleWithAnchor } from "../TitleWithAnchor";
+
+export default class Videos extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.title = props.title;
+    this.state = {
+      videos: [],
+    };
+  }
+
+  componentDidMount() {
+    this.setState({
+      videos: shuffle([
+        "https://www.youtube.com/embed/mFxs3VXABPU?start=12&enablejsapi=1",
+        "https://www.youtube.com/embed/7pmXdG8-7WU?start=7&enablejsapi=1",
+        "https://www.youtube.com/embed/_Iq1xxNZOAo?start=45&enablejsapi=1",
+        "https://www.youtube.com/embed/U3PdyHlrG1o?start=7&enablejsapi=1",
+        "https://www.youtube.com/embed/ZYBXZFKPS28?start=0&enablejsapi=1",
+        "https://www.youtube.com/embed/AV8xY318rtc?start=7&enablejsapi=1",
+        "https://www.youtube.com/embed/Qhm1Zn_BNi4?start=8&enablejsapi=1",
+        "https://www.youtube.com/embed/slBAYUDABDA?start=3&enablejsapi=1",
+        "https://www.youtube.com/embed/wyfhjr_ufag?start=6&enablejsapi=1",
+      ]),
+    });
+  }
+
+  render() {
+    return (
+      <div className="videos-section">
+        <TitleWithAnchor className="common-title-container" headerClassName="common-title" children={this.title} />
+        {this.state.videos.length > 0 && (
+          <Slider
+            beforeChange={(oldIndex) => {
+              const ref = `video-${this.state.videos[oldIndex]}`;
+              this.refs[ref].contentWindow.postMessage(
+                '{"event":"command","func":"pauseVideo","args":""}',
+                "*"
+              );
+            }}
+            prevArrow={<div>←</div>}
+            nextArrow={<div>→</div>}
+          >
+            {this.state.videos.map((src) => {
+              return (
+                <div className="video-wrapper" key={src}>
+                  <iframe
+                    ref={`video-${src}`}
+                    src={src}
+                    className="video"
+                    frameBorder="0"
+                    allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+                    allowFullScreen
+                  ></iframe>
+                </div>
+              );
+            })}
+          </Slider>
+        )}
+      </div>
+    );
+  }
+};

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -8,11 +8,25 @@ import "./header.scss";
 import "./index.css";
 import "./menu-icon.scss";
 
-const languages = {
-  '/'      : 'English',
-  '/fr-fr/': 'Français',
-  '/zh-cn/': '简体中文',
-}
+const languages = [
+  {
+    code: '/',
+    name: 'English',
+  },
+  {
+    code: '/fr-fr/',
+    name: 'Français',
+  },
+  {
+    code: '/zh-cn/',
+    name: '简体中文',
+  },
+].sort( (a, b) => a.name.toLowerCase() > b.name.toLowerCase() ? 1 : -1 );
+
+const getLanguageName = (languageCode) => {
+  return !languageCode ? '' :
+        languages.find( ({code}) => code === languageCode ).name;
+};
 
 const InfoDisclaimer = () => (
   <div className="introDisclaimer">
@@ -27,6 +41,11 @@ const HeaderDesktop = ({ language, hasLanguage, setLanguage }) => {
     setLanguage(lang)
     setIsLangMenuShown(false)
   }, [setLanguage, setIsLangMenuShown])
+
+  const languageButtons = [];
+  for (let l of languages) {
+    languageButtons.push(<button className={`button${language === l.code ? ' selected' : ''}`} onClick={() => setLang(`${l.code}`)} type="button">{l.name}</button>);
+  }
 
   return <div className="header desktop">
     <Link
@@ -47,11 +66,9 @@ const HeaderDesktop = ({ language, hasLanguage, setLanguage }) => {
       <a href="/slack">Slack</a>
       <Link to="/contribute">Contribute</Link>
       {hasLanguage && <div className="languageSelect">
-        <button className="button" onClick={() => setIsLangMenuShown(!isLangMenuShown)} type="button">{languages[language]} <span className="triangle">▾</span></button>
+        <button className="button" onClick={() => setIsLangMenuShown(!isLangMenuShown)} type="button">{getLanguageName(language)} <span className="triangle">▾</span></button>
         <div className={`list${isLangMenuShown ? ' is-shown' : ''}`}>
-          <button className={`button${language === '/' ? ' selected' : ''}`} onClick={() => setLang('/')} type="button">English</button>
-          <button className={`button${language === '/fr-fr/' ? ' selected' : ''}`} onClick={() => setLang('/fr-fr/')} type="button">Français</button>
-          <button className={`button${language === '/zh-cn/' ? ' selected' : ''}`} onClick={() => setLang('/zh-cn/')} type="button">简体中文</button>
+          {languageButtons}
         </div>
       </div>}
       <a href="https://www.cilium.io">
@@ -98,11 +115,9 @@ const HeaderMobile = ({ language, hasLanguage, setLanguage }) => {
           <a href="/slack">Slack</a>
           <Link to="/contribute">Contribute</Link>
           {hasLanguage && <div className="languageSelect">
-            <button className="button" onClick={() => setIsLangMenuShown(!isLangMenuShown)} type="button">{languages[language]} <span className="triangle">▾</span></button>
+            <button className="button" onClick={() => setIsLangMenuShown(!isLangMenuShown)} type="button">{getLanguageName(language)} <span className="triangle">▾</span></button>
             <div className={`list${isLangMenuShown ? ' is-shown' : ''}`}>
-              <button className={`button${language === '/' ? ' selected' : ''}`} onClick={() => setLang('/')} type="button">English</button>
-              <button className={`button${language === '/fr-fr/' ? ' selected' : ''}`} onClick={() => setLang('/fr-fr/')} type="button">French</button>
-              <button className={`button${language === '/zh-cn/' ? ' selected' : ''}`} onClick={() => setLang('/zh-cn/')} type="button">Chinese</button>
+              {languageButtons}
             </div>
           </div>}
           <a href="https://www.cilium.io">

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -10,6 +10,7 @@ import "./menu-icon.scss";
 
 const languages = {
   '/'      : 'English',
+  '/fr-fr/': 'Français',
   '/zh-cn/': '简体中文',
 }
 
@@ -49,6 +50,7 @@ const HeaderDesktop = ({ language, hasLanguage, setLanguage }) => {
         <button className="button" onClick={() => setIsLangMenuShown(!isLangMenuShown)} type="button">{languages[language]} <span className="triangle">▾</span></button>
         <div className={`list${isLangMenuShown ? ' is-shown' : ''}`}>
           <button className={`button${language === '/' ? ' selected' : ''}`} onClick={() => setLang('/')} type="button">English</button>
+          <button className={`button${language === '/fr-fr/' ? ' selected' : ''}`} onClick={() => setLang('/fr-fr/')} type="button">Français</button>
           <button className={`button${language === '/zh-cn/' ? ' selected' : ''}`} onClick={() => setLang('/zh-cn/')} type="button">简体中文</button>
         </div>
       </div>}
@@ -99,6 +101,7 @@ const HeaderMobile = ({ language, hasLanguage, setLanguage }) => {
             <button className="button" onClick={() => setIsLangMenuShown(!isLangMenuShown)} type="button">{languages[language]} <span className="triangle">▾</span></button>
             <div className={`list${isLangMenuShown ? ' is-shown' : ''}`}>
               <button className={`button${language === '/' ? ' selected' : ''}`} onClick={() => setLang('/')} type="button">English</button>
+              <button className={`button${language === '/fr-fr/' ? ' selected' : ''}`} onClick={() => setLang('/fr-fr/')} type="button">French</button>
               <button className={`button${language === '/zh-cn/' ? ' selected' : ''}`} onClick={() => setLang('/zh-cn/')} type="button">Chinese</button>
             </div>
           </div>}
@@ -139,7 +142,9 @@ const TemplateWrapper = ({ children, isDesktopHeaderHidden }) => {
         return;
       }
 
-      return window.location.pathname === '/' || window.location.pathname.includes('/zh-cn/');
+      return window.location.pathname === '/' ||
+            window.location.pathname.includes('/fr-fr/') ||
+            window.location.pathname.includes('/zh-cn/');
     },
 
     [],
@@ -153,11 +158,21 @@ const TemplateWrapper = ({ children, isDesktopHeaderHidden }) => {
         return;
       }
 
-      const mainPage = window.location.pathname === '/' || window.location.pathname.includes('/zh-cn/');
+      const mainPage = window.location.pathname === '/' ||
+            window.location.pathname.includes('/fr-fr/') ||
+            window.location.pathname.includes('/zh-cn/');
 
       if(mainPage) {
-        localStorage.setItem('language', window.location.pathname.includes('/zh-cn/') ? '/zh-cn/' : '/');
-        setLanguage(window.location.pathname.includes('/zh-cn/') ? '/zh-cn/' : '/');
+          if (window.location.pathname.includes('/fr-fr/')) {
+              localStorage.setItem('language', '/fr-fr/');
+              setLanguage('/fr-fr/');
+          } else if (window.location.pathname.includes('/zh-cn/')) {
+              localStorage.setItem('language', '/zh-cn/');
+              setLanguage('/zh-cn/');
+          } else {
+              localStorage.setItem('language', '/');
+              setLanguage('/');
+          }
       }
 
       if(!mainPage) {

--- a/src/pages/index.en.js
+++ b/src/pages/index.en.js
@@ -1,17 +1,13 @@
-import Helmet from "react-helmet";
 import React from "react";
 import Layout from "../layouts";
 import { graphql, Link } from 'gatsby'
-import stringSimilarity from "string-similarity";
-import { unescape, uniq, shuffle } from "lodash";
-import { format, parse as parseDate } from "date-fns";
-import Slider from "infinite-react-carousel";
-import { Post } from "../templates/post";
-import { TitleWithAnchor } from "../common/TitleWithAnchor";
+import BlogLatest from "../common/homepage/BlogLatest";
+import BlogRoll from "../common/homepage/BlogRoll";
+import HelmetBlock from "../common/homepage/Helmet";
+import MainTitle from "../common/homepage/MainTitle";
+import Section from "../common/homepage/Section";
+import Videos from "../common/homepage/Videos";
 import "../stylesheets/index.scss";
-
-const pageMetaTitle = 'eBPF - Introduction, Tutorials & Community Resources'
-const pageMetaDescription = 'eBPF is a revolutionary technology that can run sandboxed programs in the Linux kernel without changing kernel source code or loading a kernel module.'
 
 const tracingText = `
 The ability to attach eBPF programs to trace points as well as kernel and user
@@ -54,12 +50,6 @@ data required and by generating histograms and similar data structures at the
 source of the event instead of relying on the export of samples.
 `;
 
-const MainTitle = () => (
-  <hgroup>
-    <img className="main-logo" src={require("../assets/logo-big.png")} />
-  </hgroup>
-);
-
 const Buttons = () => (
   <h1 className="main-buttons">
     <Link to="/what-is-ebpf" className="main-button">
@@ -69,14 +59,6 @@ const Buttons = () => (
       Projects
     </Link>
   </h1>
-);
-
-const Section = ({ icon, iconWidth, iconHeight, title, text, ...props }) => (
-  <div className="main-section" {...props}>
-    <div className="main-section-title">{title}</div>
-    <img className="section-logo" src={icon} width={iconWidth} />
-    <div className="main-section-text">{text}</div>
-  </div>
 );
 
 const Intro = () => (
@@ -106,70 +88,6 @@ const Intro = () => (
   </div>
 );
 
-class Videos extends React.Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      videos: [],
-    };
-  }
-
-  componentDidMount() {
-    this.setState({
-      videos: shuffle([
-        "https://www.youtube.com/embed/mFxs3VXABPU?start=12&enablejsapi=1",
-        "https://www.youtube.com/embed/7pmXdG8-7WU?start=7&enablejsapi=1",
-        "https://www.youtube.com/embed/_Iq1xxNZOAo?start=45&enablejsapi=1",
-        "https://www.youtube.com/embed/U3PdyHlrG1o?start=7&enablejsapi=1",
-        "https://www.youtube.com/embed/ZYBXZFKPS28?start=0&enablejsapi=1",
-        "https://www.youtube.com/embed/AV8xY318rtc?start=7&enablejsapi=1",
-        "https://www.youtube.com/embed/Qhm1Zn_BNi4?start=8&enablejsapi=1",
-        "https://www.youtube.com/embed/slBAYUDABDA?start=3&enablejsapi=1",
-        "https://www.youtube.com/embed/wyfhjr_ufag?start=6&enablejsapi=1",
-      ]),
-    });
-  }
-
-  render() {
-    return (
-      <div className="videos-section">
-        <TitleWithAnchor className="common-title-container" headerClassName="common-title">
-          Featured eBPF Talks
-        </TitleWithAnchor>
-        {this.state.videos.length > 0 && (
-          <Slider
-            beforeChange={(oldIndex) => {
-              const ref = `video-${this.state.videos[oldIndex]}`;
-              this.refs[ref].contentWindow.postMessage(
-                '{"event":"command","func":"pauseVideo","args":""}',
-                "*"
-              );
-            }}
-            prevArrow={<div>←</div>}
-            nextArrow={<div>→</div>}
-          >
-            {this.state.videos.map((src) => {
-              return (
-                <div className="video-wrapper" key={src}>
-                  <iframe
-                    ref={`video-${src}`}
-                    src={src}
-                    className="video"
-                    frameBorder="0"
-                    allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
-                    allowFullScreen
-                  ></iframe>
-                </div>
-              );
-            })}
-          </Slider>
-        )}
-      </div>
-    );
-  }
-}
-
 const Sections = () => (
   <div className="main-sections" style={{ marginTop: "30px" }}>
     <div className="main-sections-left">
@@ -196,17 +114,6 @@ const Sections = () => (
         icon={require("../assets/intro_observability.png")}
         text={monitoringText}
       />
-    </div>
-  </div>
-);
-
-const BlogLatest = ({posts}) => (
-  <div className="blog-latest">
-    <TitleWithAnchor className="common-title-container" headerClassName="common-title">
-      Latest Blog Posts
-    </TitleWithAnchor>
-    <div className="blog-posts">
-      {posts.map(({node: post}) => <Post key={post.id} post={post} />)}
     </div>
   </div>
 );
@@ -245,186 +152,17 @@ const Outro = () => (
   </div>
 );
 
-class BlogRoll extends React.Component {
-  feeds = [
-    {
-      url: "http%3A%2F%2Fwww.brendangregg.com%2Fblog%2Frss.xml",
-      author: "Brendan Gregg",
-      filterBy: (post) => post.title.toLowerCase().includes("bpf"),
-    },
-    {
-      url:
-        "http%3A%2F%2Ffetchrss.com%2Frss%2F5f326ba08a93f8883b8b45675f326d238a93f8b34b8b4567.xml",
-      author: null,
-      filterBy: (post) =>
-        post.title.toLowerCase().includes("bpf") &&
-        post.link !==
-          "https://facebookmicrosites.github.io/bpf/blog/2018/08/31/welcome.html",
-    },
-    {
-      url: "https%3A%2F%2Fcilium.io%2Fblog%2Frss.xml",
-      author: "Cilium authors",
-      filterBy: (post) =>
-        post.categories.some((category) =>
-          category.toLowerCase().includes("announcements")
-        ),
-    },
-    {
-      url: "https%3A%2F%2Fqmonnet.github.io%2Fwhirl-offload%2Ffeed.xml",
-      author: "Quentin Monnet",
-      filterBy: (post) => post.title.toLowerCase().includes("bpf"),
-    },
-    {
-      url: "https%3A%2F%2Fpchaigno.github.io%2Ffeed.xml",
-      author: "Paul Chaignon",
-      filterBy: (post) => post.title.toLowerCase().includes("bpf"),
-    },
-    {
-      url: "https%3A%2F%2Fnakryiko.com%2Fatom.xml",
-      author: "Andrii Nakryiko",
-      filterBy: (post) => post.title.toLowerCase().includes("bpf") || post.title.toLowerCase().includes("btf"),
-    },
-  ];
-
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      posts: [],
-    };
-  }
-
-  componentDidMount() {
-    const apiUrl = "https://api.rss2json.com/v1/api.json";
-    const apiKey = process.env.RSS2JSON_API_KEY;
-    Promise.all(
-      this.feeds.map((feed) =>
-        fetch(`${apiUrl}?api_key=${apiKey}&rss_url=${feed.url}`)
-          .then((r) => r.json())
-          .then((post) => ({ feed, post }))
-      )
-    )
-      .then((results) => {
-        results.map((result) => {
-          if(result.post.status !== 'ok') {
-            console.error(`Feed ${result.post.feed.url} is temporary unavailable`)
-          }
-        });
-        return results
-          .filter((result) => result.post.status === 'ok')
-          .reduce((acc, { feed, post: { items } }) => {
-          return acc.concat(
-            items
-              .map((post) => ({
-                ...post,
-                pubDate: parseDate(
-                  post.pubDate,
-                  "yyyy-MM-dd HH:mm:ss",
-                  new Date()
-                ),
-                author: post.author || feed.author,
-              }))
-              .sort((a, b) => b.pubDate - a.pubDate)
-              .filter(
-                (post) =>
-                  feed.filterBy(post) && post.pubDate.getFullYear() >= 2018
-              )
-              .slice(0, 3)
-          );
-        }, []);
-      })
-      .then((posts) => {
-        let uniqPosts = posts;
-        posts.forEach((initialPost) => {
-          uniqPosts.forEach((resultPost, idx) => {
-            /*
-              If two posts have same author, come from different websites and have similar titles — remove the second
-              one. Website check is necessary in case of such posts like "eBPF Summit Day 1 Recap" and
-              "eBPF Summit Day 2 Recap". Because within a single website uniqueness is controlled manually by editors
-              and thus posts with similar titles are rarely added on occasion.
-            */
-            if(
-              (initialPost.author || '').toLowerCase() === (resultPost.author || '').toLowerCase() &&
-              new URL(initialPost.link).host !== new URL(resultPost.link).host &&
-              stringSimilarity.compareTwoStrings(initialPost.title, resultPost.title) >= 0.75
-            ) {
-              uniqPosts.splice(idx, 1)
-            }
-          });
-        });
-        uniqPosts.sort((a, b) => b.pubDate - a.pubDate);
-        return uniqPosts;
-      })
-      .then((posts) => {
-        this.setState({ posts });
-      })
-      .catch((error) => console.error(error));
-  }
-
-  render() {
-    return (
-      <div className="blog-roll-section">
-        <TitleWithAnchor  className="common-title-container" headerClassName="common-title">
-          Featured eBPF Community Blogs
-        </TitleWithAnchor>
-        {this.state.posts.length === 0 && (
-          <div className="blog-roll-loading">Loading...</div>
-        )}
-        {this.state.posts.length > 0 && (
-          <ul>
-            {this.state.posts.map((post) => {
-              return (
-                <li key={post.link}>
-                  <a
-                    href={post.link}
-                    className="blog-roll-item"
-                    target="_blank"
-                  >
-                    <span className="blog-roll-date">
-                      {format(post.pubDate, "MMM d, yyyy")}
-                    </span>{" "}
-                    <span className="blog-roll-title">
-                      <u>{unescape(post.title)}</u>{" "}
-                      <span className="blog-roll-author">{post.author}</span>
-                    </span>
-                  </a>
-                </li>
-              );
-            })}
-          </ul>
-        )}
-      </div>
-    );
-  }
-}
-
 const IndexPage = ({ data }) => {
   return <Layout>
     <div className="page-wrapper page-index">
-      <Helmet
-        title={pageMetaTitle}
-
-        meta={[
-          {name: "keywords", content: "ebpf, bpf, xdp, introduction, tutorial, documentation, deep dive, community"},
-          {name: "type", property: "og:type", content: "website"},
-          {name: "url", property: "og:url", content: "https://ebpf.io/"},
-          {name: "title", property: "og:title", content: pageMetaTitle},
-          {name: "description", property: "og:description", content: pageMetaDescription},
-          {name: "image", property: "og:image", content: 'https://ebpf.io' + require("../assets/ogimage.png")},
-          {name: "twitter:card", content: "summary_large_image"},
-          {name: "twitter:url", content: "https://ebpf.io/"},
-          {name: "twitter:title", content: pageMetaTitle},
-          {name: "twitter:description", content: pageMetaDescription},
-          {name: "twitter:image", content: 'https://ebpf.io' + require("../assets/ogimage.png")},
-        ]}
-      />
+      <HelmetBlock />
       <MainTitle />
       <Buttons />
       <Intro />
       <Sections />
-      <Videos />
-      <BlogLatest posts={data.allMarkdownRemark.edges} />
-      <BlogRoll />
+      <Videos title="Featured eBPF Talks" />
+      <BlogLatest title="Latest Blog Posts" posts={data.allMarkdownRemark.edges} />
+      <BlogRoll title="Featured eBPF Community Blogs"/>
       <Outro />
     </div>
   </Layout>

--- a/src/pages/index.fr-fr.js
+++ b/src/pages/index.fr-fr.js
@@ -1,0 +1,202 @@
+import React from "react";
+import Layout from "../layouts";
+import { graphql, Link } from 'gatsby'
+import BlogLatest from "../common/homepage/BlogLatest";
+import BlogRoll from "../common/homepage/BlogRoll";
+import HelmetBlock from "../common/homepage/Helmet";
+import MainTitle from "../common/homepage/MainTitle";
+import Section from "../common/homepage/Section";
+import Videos from "../common/homepage/Videos";
+import "../stylesheets/index.scss";
+
+const tracingText = `
+La possibilité d'attacher des programmes eBPF sur des « trace points » et des
+« probe points », que ce soit dans le noyau ou dans les applications
+utilisateurs, apporte une dimension nouvelle en termes de visibilité. Les
+deux vues produites par l'introspection du noyau, d'une part, et du
+comportement des applications en cours, d'autre part, peuvent être combinées
+pour obtenir une perspective unique et déterminante sur le système, et pour
+résoudre les problèmes de performance. Des structures de données élaborées
+permettent de collecter des indicateurs statistiques et d'extraire
+l'information utile de manière efficace, sans passer par un export constant
+d'échantillons de données comme le font les systèmes traditionnels.
+`;
+
+const securityText = `
+eBPF permet d'observer et de comprendre tous les appels système, et de se
+placer au niveau des paquets et des sockets pour obtenir une vision de toutes
+les opérations réseau. La combinaison de ces éléments forme une fondation sans
+précédent pour sécuriser les systèmes d'information. Alors même que le filtrage
+des appels système, la régulation des flux réseaux, et le suivi du contexte
+d'exécution des processus sont typiquement gérés par des solutions distinctes,
+eBPF offre à la fois vision et contrôle sur tous les composants, ouvrant ainsi
+la voie à un système de sécurisation qui porte sur un domaine plus large, et
+propose un contrôle plus poussé.
+`;
+
+const networkingText = `
+La programmabilité et la performance d'eBPF en font une solution idéale pour le
+traitement de paquets pour tous types d'applications réseau. Programmer avec
+eBPF permet d'analyser et d'implémenter de nouveaux protocoles, d'appliquer une
+logique de routage des paquets pour répondre à des besoins en évolution
+constante, sans jamais quitter le contexte du noyau Linux. Le compilateur JIT
+(« Just-In-Time », compilation à la volée) permet d'atteindre, à l'exécution
+des programmes, des performances similaires à celles du code compilé nativement
+dans le noyau.
+`;
+
+const monitoringText = `
+Au lieu de se baser sur des jauges et des compteurs statiques exposés par le
+système d'exploitation, eBPF collecte et agrège dans le noyau des métriques
+personnalisées, et rend possible la génération d'observations basées sur un
+large éventail de sources disponibles. Seules les données utiles sont relevées,
+et les représentations telles que les histogrammes sont générées à la source de
+l'évènement plutôt qu'à la réception d'un flot d'échantillons exportés du
+noyau. eBPF offre ainsi une visibilité du système avec une portée accrue, tout
+en réduisant significativement le cout associé à la collecte de données.
+`;
+
+const Buttons = () => (
+  <h1 className="main-buttons">
+    <Link to="/what-is-ebpf" className="main-button">
+      Comprendre eBPF
+    </Link>
+    <Link to="/projects" className="main-button">
+      Projets
+    </Link>
+  </h1>
+);
+
+const Intro = () => (
+  <div className="intro">
+    <p>
+      Le noyau Linux a toujours été l'endroit idéal pour implémenter les
+      aspects inspection/supervision, réseau, et sécurité du système.
+      Malheureusement, la nécessité de changer le code du noyau ou de charger
+      des modules rend la tâche contraignante, et revient souvent à empiler les
+      couches d'abstraction. eBPF est une technologie révolutionnaire
+      permettant d'exécuter des programmes au sein du noyau Linux, dans un
+      environnement confiné, sans changer le code source du noyau ni charger de
+      modules.
+    </p>
+    <p>
+      Grâce à cette capacité à programmer le noyau, les composants logiciels
+      peuvent s'appuyer sur le système existant. Ils viennent le perfectionner
+      et l'enrichir en fonctionnalités, en évitant de rajouter des couches
+      d'abstraction, mais sans compromettre l'efficacité ou la sureté du
+      système.
+    </p>
+    <img src={require("../assets/go.png")} />
+    <p>
+      eBPF a conduit au développement d'une nouvelle génération d'applications,
+      capables de reprogrammer le noyau Linux, et même de mettre en œuvre une
+      logique commune à différents sous-systèmes du noyau, jusqu'ici décorrélés
+      les uns des autres.
+    </p>
+  </div>
+);
+
+const Sections = () => (
+  <div className="main-sections" style={{ marginTop: "30px" }}>
+    <div className="main-sections-left">
+      <Section
+        title="Sécurité"
+        icon={require("../assets/intro_security.png")}
+        text={securityText}
+      />
+      <Section
+        title="Réseau"
+        icon={require("../assets/intro_networking.png")}
+        text={networkingText}
+      />
+    </div>
+    <div className="main-sections-right">
+      <Section
+        title="Traçage et profilage"
+        icon={require("../assets/intro_tracing.png")}
+        text={tracingText}
+      />
+      <Section
+        title="Observabilité et supervision"
+        icon={require("../assets/intro_observability.png")}
+        text={monitoringText}
+      />
+    </div>
+  </div>
+);
+
+const Outro = () => (
+  <div className="intro">
+    <p>
+      Pour en apprendre plus sur eBPF et ses applications :
+      <table width="100%">
+        <tr>
+          <td>
+            <ul>
+              <li>
+                <a href="/what-is-ebpf">Comprendre eBPF</a>
+              </li>
+              <li>
+                <a href="/projects">Liste de projets basés sur eBPF</a>
+              </li>
+            </ul>
+          </td>
+          <td>
+            <ul>
+              <li>
+                <a href="/slack">
+                  Rejoindre la communauté #ebpf sur Slack
+                </a>
+              </li>
+              <li>
+                <a href="/contribute">Comment contribuer</a>
+              </li>
+            </ul>
+          </td>
+        </tr>
+      </table>
+    </p>
+  </div>
+);
+
+const IndexPage = ({ data }) => {
+  return <Layout>
+    <div className="page-wrapper page-index">
+      <HelmetBlock />
+      <MainTitle />
+      <Buttons />
+      <Intro />
+      <Sections />
+      <Videos title="Découvrir eBPF en vidéo" />
+      <BlogLatest title="Les derniers articles du blog" posts={data.allMarkdownRemark.edges} />
+      <BlogRoll title="Sélection d'articles de blogs par la communauté eBPF" />
+      <Outro />
+    </div>
+  </Layout>
+};
+
+export default IndexPage;
+
+export const pageQuery = graphql`
+  query FRIndexQuery {
+    allMarkdownRemark(
+      sort: { order: DESC, fields: [frontmatter___date] }
+      limit: 2
+    ) {
+      edges {
+        node {
+          html
+          id
+          excerpt
+          frontmatter {
+            categories
+            date
+            path
+            title
+            tags
+          }
+        }
+      }
+    }
+  }
+`;

--- a/src/pages/index.zh-cn.js
+++ b/src/pages/index.zh-cn.js
@@ -1,48 +1,41 @@
 import React from "react";
-import Link from "gatsby-link";
-import { unescape, shuffle } from "lodash";
-import { format, parse as parseDate } from "date-fns";
-import Slider from "infinite-react-carousel";
 import Layout from "../layouts";
-import { graphql } from "gatsby";
-import { Post } from "../templates/post";
-import Helmet from "react-helmet";
-
+import { graphql, Link } from 'gatsby'
+import BlogLatest from "../common/homepage/BlogLatest";
+import BlogRoll from "../common/homepage/BlogRoll";
+import HelmetBlock from "../common/homepage/Helmet";
+import MainTitle from "../common/homepage/MainTitle";
+import Section from "../common/homepage/Section";
+import Videos from "../common/homepage/Videos";
 import "../stylesheets/index.scss";
-
-const pageMetaTitle = 'eBPF - Introduction, Tutorials & Community Resources'
-const pageMetaDescription = 'eBPF is a revolutionary technology that can run sandboxed programs in the Linux kernel without changing kernel source code or loading a kernel module.'
 
 const tracingText = `
 eBPF 程序能够加载到 trace points、内核及用户空间应用程序中的 probe points，
 这种能力使我们对应用程序的运行时行为（runtime behavior）和系统本身
 （system itself）提供了史无前例的可观测性。应用端和系统端的这种观测能力相结合，
 能在排查系统性能问题时提供强大的能力和独特的信息。BPF 使用了很多高级数据结构，
-因此能非常高效地导出有意义的可观测数据，而不是像很多同类系统一样导出海量的原始采样数据。`;
+因此能非常高效地导出有意义的可观测数据，而不是像很多同类系统一样导出海量的原始采样数据。
+`;
 
 const securityText = `
 观测和理解所有的系统调用的能力，以及在 packet 层和 socket 层审视所有的网络操作的能力，
 这两者相结合，为系统安全提供了革命性的新方法。
 以前，系统调用过滤、网络层过滤和进程上下文跟踪是在完全独立的系统中完成的；
 eBPF 的出现统一了可观测性和各层面的控制能力，使我们有更加丰富的上下文和更精细的控制能力，
-因而能创建更加安全的系统。`;
+因而能创建更加安全的系统。
+`;
 
 const networkingText = `
 eBPF 的两大特色 —— 可编程和高性能 —— 使它能满足所有的网络包处理需求。
 可编程意味着无需离开内核中的包处理上下文，就能添加额外的协议解析器或任何转发逻辑，
-以满足不断变化的需求。高性能的 JIT 编译器使 eBPF 程序能达到几乎与原生编译的内核态代码一样的执行性能。`;
+以满足不断变化的需求。高性能的 JIT 编译器使 eBPF 程序能达到几乎与原生编译的内核态代码一样的执行性能。
+`;
 
 const monitoringText = `
 相比于操作系统提供的静态计数器（counters、gauges），eBPF 能在内核中收集和聚合自定义 metric，
 并能从不同数据源来生成可观测数据。这既扩展了可观测性的深度，也显著减少了整体系统开销，
 因为现在可以选择只收集需要的数据，并且后者是直方图或类似的格式，而非原始采样数据。
 `;
-
-const Title = () => (
-  <hgroup>
-    <img className="main-logo" src={require("../assets/logo-big.png")} />
-  </hgroup>
-);
 
 const Buttons = () => (
   <h1 className="main-buttons">
@@ -53,14 +46,6 @@ const Buttons = () => (
       项目列表
     </Link>
   </h1>
-);
-
-const Section = ({ icon, iconWidth, iconHeight, title, text, ...props }) => (
-  <div className="main-section" {...props}>
-    <div className="main-section-title">{title}</div>
-    <img className="section-logo" src={icon} width={iconWidth} />
-    <div className="main-section-text">{text}</div>
-  </div>
 );
 
 const Intro = () => (
@@ -84,64 +69,6 @@ const Intro = () => (
     </p>
   </div>
 );
-
-class Videos extends React.Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      videos: [],
-    };
-  }
-
-  componentDidMount() {
-    this.setState({
-      videos: shuffle([
-        "https://www.youtube.com/embed/mFxs3VXABPU?start=12&enablejsapi=1",
-        "https://www.youtube.com/embed/7pmXdG8-7WU?start=7&enablejsapi=1",
-        "https://www.youtube.com/embed/_Iq1xxNZOAo?start=45&enablejsapi=1",
-        "https://www.youtube.com/embed/U3PdyHlrG1o?start=7&enablejsapi=1",
-        "https://www.youtube.com/embed/ZYBXZFKPS28?start=0&enablejsapi=1",
-      ]),
-    });
-  }
-
-  render() {
-    return (
-      <div className="videos-section">
-        <h2>eBPF 相关演讲</h2>
-        {this.state.videos.length > 0 && (
-          <Slider
-            dots
-            arrows={false}
-            beforeChange={(oldIndex) => {
-              const ref = `video-${this.state.videos[oldIndex]}`;
-              this.refs[ref].contentWindow.postMessage(
-                '{"event":"command","func":"pauseVideo","args":""}',
-                "*"
-              );
-            }}
-          >
-            {this.state.videos.map((src) => {
-              return (
-                <div className="video-wrapper" key={src}>
-                  <iframe
-                    ref={`video-${src}`}
-                    src={src}
-                    className="video"
-                    frameBorder="0"
-                    allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
-                    allowFullScreen
-                  ></iframe>
-                </div>
-              );
-            })}
-          </Slider>
-        )}
-      </div>
-    );
-  }
-}
 
 const Sections = () => (
   <div className="main-sections" style={{ marginTop: "30px" }}>
@@ -173,15 +100,6 @@ const Sections = () => (
   </div>
 );
 
-const BlogLatest = ({ posts }) => (
-  <div className="blog-latest">
-    <h2>最新博客</h2>
-    <div className="blog-posts">
-      {posts.map(({node: post}) => <Post key={post.id} post={post} />)}
-    </div>
-  </div>
-);
-
 const Outro = () => (
   <div className="intro">
     <p>
@@ -201,7 +119,7 @@ const Outro = () => (
           <td>
             <ul>
               <li>
-                <a href="https://cilium.herokuapp.com/">
+                <a href="/slack">
                   加入 #ebpf Slack 社区
                 </a>
               </li>
@@ -216,160 +134,21 @@ const Outro = () => (
   </div>
 );
 
-class BlogRoll extends React.Component {
-  feeds = [
-    {
-      url:
-        "https://api.rss2json.com/v1/api.json?rss_url=http%3A%2F%2Fwww.brendangregg.com%2Fblog%2Frss.xml",
-      author: "Brendan Gregg",
-      filterBy: (post) => post.title.toLowerCase().includes("bpf"),
-    },
-    {
-      url:
-        "https://api.rss2json.com/v1/api.json?rss_url=http%3A%2F%2Ffetchrss.com%2Frss%2F5f326ba08a93f8883b8b45675f326d238a93f8b34b8b4567.xml",
-      author: null,
-      filterBy: (post) =>
-        post.title.toLowerCase().includes("bpf") &&
-        post.link !==
-        "https://facebookmicrosites.github.io/bpf/blog/2018/08/31/welcome.html",
-    },
-    {
-      url:
-        "https://api.rss2json.com/v1/api.json?rss_url=https%3A%2F%2Fcilium.io%2Fblog%2Frss.xml",
-      author: "Cilium authors",
-      filterBy: (post) =>
-        post.categories.some((category) =>
-          category.toLowerCase().includes("announcements")
-        ),
-    },
-    {
-      url:
-        "https://api.rss2json.com/v1/api.json?rss_url=https%3A%2F%2Fqmonnet.github.io%2Fwhirl-offload%2Ffeed.xml",
-      author: "Quentin Monnet",
-      filterBy: (post) => post.title.toLowerCase().includes("bpf"),
-    },
-    {
-      url:
-        "https://api.rss2json.com/v1/api.json?rss_url=https%3A%2F%2Fpchaigno.github.io%2Ffeed.xml",
-      author: "Paul Chaignon",
-      filterBy: (post) => post.title.toLowerCase().includes("bpf"),
-    },
-  ];
-
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      posts: [],
-    };
-  }
-
-  componentDidMount() {
-    Promise.all(
-      this.feeds.map((feed) =>
-        fetch(feed.url)
-          .then((r) => r.json())
-          .then((post) => ({ feed, post }))
-      )
-    )
-      .then((results) => {
-        return results.reduce((acc, { feed, post: { items } }) => {
-          return acc.concat(
-            items
-              .map((post) => ({
-                ...post,
-                pubDate: parseDate(
-                  post.pubDate,
-                  "yyyy-MM-dd hh:mm:ss",
-                  new Date()
-                ),
-                author: post.author || feed.author,
-              }))
-              .sort((a, b) => b.pubDate - a.pubDate)
-              .filter(
-                (post) =>
-                  feed.filterBy(post) && post.pubDate.getFullYear() >= 2018
-              )
-              .slice(0, 3)
-          );
-        }, []);
-      })
-      .then((posts) => {
-        posts.sort((a, b) => b.pubDate - a.pubDate);
-        return posts;
-      })
-      .then((posts) => {
-        this.setState({ posts });
-      })
-      .catch((error) => console.error(error));
-  }
-
-  render() {
-    return (
-      <div className="blog-roll-section">
-        <h2>eBPF 相关文章</h2>
-        {this.state.posts.length === 0 && (
-          <div className="blog-roll-loading">Loading...</div>
-        )}
-        {this.state.posts.length > 0 && (
-          <ul>
-            {this.state.posts.map((post) => {
-              return (
-                <li key={post.link}>
-                  <a
-                    href={post.link}
-                    className="blog-roll-item"
-                    target="_blank"
-                  >
-                    <span className="blog-roll-date">
-                      {format(post.pubDate, "MMM d, yyyy")}
-                    </span>{" "}
-                    <span className="blog-roll-title">
-                      <u>{unescape(post.title)}</u>{" "}
-                      <span className="blog-roll-author">{post.author}</span>
-                    </span>
-                  </a>
-                </li>
-              );
-            })}
-          </ul>
-        )}
-      </div>
-    );
-  }
-}
-
-const IndexPage = ({ data }) => (
-  <Layout>
+const IndexPage = ({ data }) => {
+  return <Layout>
     <div className="page-wrapper page-index">
-      <Helmet
-        title={pageMetaTitle}
-
-        meta={[
-          {name: "keywords", content: "ebpf, bpf, xdp, introduction, tutorial, documentation, deep dive, community"},
-          {name: "type", property: "og:type", content: "website"},
-          {name: "url", property: "og:url", content: "https://ebpf.io/"},
-          {name: "title", property: "og:title", content: pageMetaTitle},
-          {name: "description", property: "og:description", content: pageMetaDescription},
-          {name: "image", property: "og:image", content: 'https://ebpf.io' + require("../assets/ogimage.png")},
-          {name: "twitter:card", content: "summary_large_image"},
-          {name: "twitter:url", content: "https://ebpf.io/"},
-          {name: "twitter:title", content: pageMetaTitle},
-          {name: "twitter:description", content: pageMetaDescription},
-          {name: "twitter:image", content: 'https://ebpf.io' + require("../assets/ogimage.png")},
-        ]}
-      />
-      <Title />
+      <HelmetBlock />
+      <MainTitle />
       <Buttons />
       <Intro />
       <Sections />
-      <Videos />
-      <BlogLatest posts={data.allMarkdownRemark.edges} />
-      <BlogRoll />
+      <Videos title="eBPF 相关演讲" />
+      <BlogLatest title="最新博客" posts={data.allMarkdownRemark.edges} />
+      <BlogRoll title="eBPF 相关文章" />
       <Outro />
     </div>
   </Layout>
-);
+};
 
 export default IndexPage;
 


### PR DESCRIPTION
We now have a Chinese translation of the homepage. Why not a French one?

The first commit is a clean-up to consolidate the code which is common to the different versions of the homepage. A few differences between the English and the Chinese versions sneaked in already, copying all the code when adding other translations will make it unmaintainable.

The second one adds the translation itself.

The third one sorts the language alphabetically in the selector (and automates the generation of the list).