### PR TITLE
complete renaming and redirection from /news to /blog

### DIFF
--- a/src/posts/2020-11-20-ebpf-updates/index.md
+++ b/src/posts/2020-11-20-ebpf-updates/index.md
@@ -1,5 +1,5 @@
 ---
-path: "/news/ebpf-updates-intro"
+path: "/blog/ebpf-updates-intro"
 date: "2020-11-20T10:00:00.000Z"
 title: "eBPF Updates #1: eBPF Summit Coverage, libbpf 0.2, BTF Developments, Bulk API for XDP, Local Task Storage for eBPF LSM"
 tags:

--- a/src/posts/2020-12-21-ebpf-updates/index.md
+++ b/src/posts/2020-12-21-ebpf-updates/index.md
@@ -1,5 +1,5 @@
 ---
-path: "/news/ebpf-updates-2020-12"
+path: "/blog/ebpf-updates-2020-12"
 date: "2020-12-18T10:00:00.000Z"
 title: "eBPF Updates #2: eBPF with Zig, libbpf-bootstrap, Rust Linker, BTF in Kernel Modules, Cgroup-Based Memory Accounting"
 tags:

--- a/src/posts/2021-01-22-ebpf-updates/index.md
+++ b/src/posts/2021-01-22-ebpf-updates/index.md
@@ -1,5 +1,5 @@
 ---
-path: "/news/ebpf-updates-2021-01"
+path: "/blog/ebpf-updates-2021-01"
 date: "2021-01-22T10:00:00.000Z"
 title: "eBPF Updates #3: Atomics Operations, Socket Options Retrieval, Syscall Tracing Benchmarks, eBPF in the Supply Chain"
 tags:

--- a/src/posts/2021-02-23-ebpf-updates/index.md
+++ b/src/posts/2021-02-23-ebpf-updates/index.md
@@ -1,5 +1,5 @@
 ---
-path: "/news/ebpf-updates-2021-02"
+path: "/blog/ebpf-updates-2021-02"
 date: "2021-02-23T10:00:00.000Z"
 title: "eBPF Updates #4: In-Memory Loads Detection, Debugging QUIC, Local CI Runs, MTU Checks, but No Pancakes"
 tags:

--- a/src/templates/blog.js
+++ b/src/templates/blog.js
@@ -25,13 +25,13 @@ export default function NewsIndex({ data, pageContext }) {
           meta={[
             {name: "keywords", content: "ebpf, bpf, news, updates, blog"},
             {name: "type", property: "og:type", content: "website"},
-            {name: "url", property: "og:url", content: "https://ebpf.io/news"},
+            {name: "url", property: "og:url", content: "https://ebpf.io/blog"},
             {name: "title", property: "og:title", content: pageMetaTitle},
             {name: "description", property: "og:description", content: pageMetaDescription},
             {name: "description", content: pageMetaDescription},
             {name: "image", property: "og:image", content: pageMetaImageUrl},
             {name: "twitter:card", content: "summary_large_image"},
-            {name: "twitter:url", content: "https://ebpf.io/news"},
+            {name: "twitter:url", content: "https://ebpf.io/blog"},
             {name: "twitter:title", content: pageMetaTitle},
             {name: "twitter:description", content: pageMetaDescription},
             {name: "twitter:image", content: pageMetaImageUrl},
@@ -41,7 +41,7 @@ export default function NewsIndex({ data, pageContext }) {
             rel="alternate"
             type="application/rss+xml"
             title="RSS Feed"
-            href="/news/rss.xml"
+            href="/blog/rss.xml"
           />
         </Helmet>
 
@@ -50,10 +50,10 @@ export default function NewsIndex({ data, pageContext }) {
         ))}
         <div className="prev-next-links blog-post">
           <div className="prev-link">
-            {!first && <NavLink url={`/news/${prevUrl}`} text="« Newer Posts" />}
+            {!first && <NavLink url={`/blog/${prevUrl}`} text="« Newer Posts" />}
           </div>
           <div className="next-link">
-            {!last && <NavLink url={`/news/${nextUrl}`} text="Older Posts »" />}
+            {!last && <NavLink url={`/blog/${nextUrl}`} text="Older Posts »" />}
           </div>
         </div>
       </div>

--- a/src/templates/post.js
+++ b/src/templates/post.js
@@ -63,7 +63,7 @@ export const Post = ({ post, full }) => {
           <div className="blog-post-tags">
             {tags.map((tag, i) => tag !== '_' && (
               <span className="blog-post-tag" key={tag}>
-              <a href={`/news/tags/${tag.toLowerCase().replace(' ', '-')}`}>{tag}</a>
+              <a href={`/blog/tags/${tag.toLowerCase().replace(' ', '-')}`}>{tag}</a>
             </span>
             ))}
           </div>

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,2 +1,2 @@
-/news/rss.xml /blog/rss.xml
-/news /blog
+# Redirect all pages under /news/ to the equivalent path under /blog/
+/news/* /blog/:splat


### PR DESCRIPTION
PR #92 renamed `/news` to `/blog`, but some items were not converted. In particular, because the paths in the blog post headers were not renamed, I copy-pasted the path prefixes and unintentionally kept placing the new posts under `/news/`.

This commit:

- Fixes the paths defined in the headers of the posts
- Updates a few elements from the templates, apparently omitted in the previous conversion
- Uses a splat to redirect everything under /news/ to /blog/, so that we redirect the existing posts in addition to the blog page and RSS feed (https://docs.netlify.com/routing/redirects/redirect-options/#splats).

Fixes: #92

Note: I couldn't check the redirects locally (`_redirects` is interpreted by Netlify, not by yarn) so we must triple-check that the main page, the RSS feed, the existing posts are all accessible under `/news/` as well as `/blog/` before merging.