### PR TITLE
Filter pchaigno.github.io's posts by category

### DIFF
--- a/src/common/homepage/BlogRoll.js
+++ b/src/common/homepage/BlogRoll.js
@@ -36,7 +36,10 @@ export default class BlogRoll extends React.Component {
     {
       url: "https%3A%2F%2Fpchaigno.github.io%2Ffeed.xml",
       author: "Paul Chaignon",
-      filterBy: (post) => post.title.toLowerCase().includes("bpf"),
+      filterBy: (post) =>
+        post.categories.some((category) =>
+          category.toLowerCase().includes("bpf")
+        ),
     },
     {
       url: "https%3A%2F%2Fnakryiko.com%2Fatom.xml",


### PR DESCRIPTION
Reapply commit 690df17 ("Filter pchaigno.github.io's posts by category") which was reverted by mistake in https://github.com/cilium/ebpf.io/pull/81.

Fixes: https://github.com/cilium/ebpf.io/pull/81
Reported-by: Quentin Monnet <quentin@isovalent.com>
Signed-off-by: Paul Chaignon <paul@cilium.io>