### PR TITLE
Update style on "Conferences" menu in the header

### DIFF
--- a/src/layouts/header.scss
+++ b/src/layouts/header.scss
@@ -158,7 +158,7 @@ $lg: "screen and (max-width : 1024px)";
         border: none;
         cursor: pointer;
         &:hover {
-          color: #5f4b0f;
+          background-color: #fff1cc;
         }
         &:focus {
           outline: none;
@@ -181,6 +181,13 @@ $lg: "screen and (max-width : 1024px)";
           }
         }
       }
+      & > strong {
+        margin-bottom: 1ex;
+        display: inline-block;
+      }
+      & > strong:not(:first-child) {
+        margin-top: 1ex;
+      }
       & > .link {
         appearance: none;
         position: relative;
@@ -190,12 +197,13 @@ $lg: "screen and (max-width : 1024px)";
         text-decoration: none;
         font-weight: 600;
         font-size: 14px;
-        text-align: right;
         background: none;
         border: none;
         cursor: pointer;
+        margin-left: 0;
+        padding-left: 40px;
         &:hover {
-          color: rgb(75, 75, 75);
+          background-color: #fff1cc;
         }
         &:focus {
           outline: none;


### PR DESCRIPTION
Small style update for the "Conferences" menu in the header:

- Do not right-align the items in the menu, but instead left-align with some padding.

- Do not use a slight variation of grey for the font color on hovering, but instead change the background color to make the selection more visible. This is also reported to the language selection menu.

![comp](https://user-images.githubusercontent.com/17001771/122549221-27cecc00-d02a-11eb-8b42-0c9fe51083e1.png)
