### PR TITLE
Add new menu items in header & mobile

### DIFF
--- a/src/layouts/header.scss
+++ b/src/layouts/header.scss
@@ -105,6 +105,10 @@ $lg: "screen and (max-width : 1024px)";
   & > .languageSelect {
     margin-left: 40px;
     position: relative;
+    &.about .list .link{
+      padding-left: 20px;
+      padding-right: 20px;
+    }
     & > .button {
       appearance: none;
       color: #000;
@@ -226,6 +230,11 @@ $lg: "screen and (max-width : 1024px)";
     & > .languageSelect {
       margin-left: 0;
       margin-bottom: 15px;
+      & > .button {
+        display: flex;
+        width: 100%;
+        justify-content: center;
+      }
       & > .list {
         margin-top: 15px;
         position: static;
@@ -265,7 +274,7 @@ a.contactUs {
 .header.desktop .headerNav {
   flex-direction: row;
 
-  a {
+  > a {
     margin-left: 40px;
 
     &:first-child {

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -165,7 +165,6 @@ const HeaderMobile = ({ language, hasLanguage, setLanguage }) => {
             </span>
           </span>
           <a href="/slack">Slack</a>
-          <Link to="/contribute">Contribute</Link>
           <span className="languageSelect about">
             <button className="button" onClick={() => setIsAboutMenuShown(!isAboutMenuShown)} type="button">About <span className="triangle">▾</span></button>
             <span className={`list${isAboutMenuShown ? ' is-shown' : ''}`}>

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -87,8 +87,8 @@ const HeaderDesktop = ({ language, hasLanguage, setLanguage }) => {
         <button className="button" onClick={() => setIsAboutMenuShown(!isAboutMenuShown)} type="button">About <span className="triangle">▾</span></button>
         <span className={`list${isAboutMenuShown ? ' is-shown' : ''}`}>
           <Link className="link" to="/members">Members</Link>
-          <Link className="link" to="/governing-board">Governing board</Link>
-          <Link className="link" to="/steering-committee">eBPF Steering Committee</Link>
+          {/* <Link className="link" to="/governing-board">Governing board</Link>
+          <Link className="link" to="/steering-committee">eBPF Steering Committee</Link> */}
           <Link className="link" to="/charter">Charter</Link>
           <Link className="link" to="/contribute">How to Contribute</Link>
         </span>
@@ -169,8 +169,8 @@ const HeaderMobile = ({ language, hasLanguage, setLanguage }) => {
             <button className="button" onClick={() => setIsAboutMenuShown(!isAboutMenuShown)} type="button">About <span className="triangle">▾</span></button>
             <span className={`list${isAboutMenuShown ? ' is-shown' : ''}`}>
               <Link className="link" to="/members">Members</Link>
-              <Link className="link" to="/governing-board">Governing board</Link>
-              <Link className="link" to="/steering-committee">eBPF Steering Committee</Link>
+              {/* <Link className="link" to="/governing-board">Governing board</Link>
+              <Link className="link" to="/steering-committee">eBPF Steering Committee</Link> */}
               <Link className="link" to="/charter">Charter</Link>
               <Link className="link" to="/contribute">How to Contribute</Link>
             </span>

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -37,6 +37,7 @@ const InfoDisclaimer = () => (
 const HeaderDesktop = ({ language, hasLanguage, setLanguage }) => {
   const [isLangMenuShown, setIsLangMenuShown] = useState(false)
   const [isConferencesMenuShown, setIsConferencesMenuShown] = useState(false)
+  const [isAboutMenuShown, setIsAboutMenuShown] = useState(false)
 
   const setLang = useCallback(lang => {
     setLanguage(lang)
@@ -82,7 +83,16 @@ const HeaderDesktop = ({ language, hasLanguage, setLanguage }) => {
         </span>
       </span>
       <a href="/slack">Slack</a>
-      <Link to="/contribute">Contribute</Link>
+      <span className="languageSelect about">
+        <button className="button" onClick={() => setIsAboutMenuShown(!isAboutMenuShown)} type="button">About <span className="triangle">▾</span></button>
+        <span className={`list${isAboutMenuShown ? ' is-shown' : ''}`}>
+          <Link className="link" to="/members">Members</Link>
+          <Link className="link" to="/governing-board">Governing board</Link>
+          <Link className="link" to="/steering-committee">eBPF Steering Committee</Link>
+          <Link className="link" to="/charter">Charter</Link>
+          <Link className="link" to="/contribute">How to Contribute</Link>
+        </span>
+      </span>
       {hasLanguage && <span className="languageSelect">
         <button className="button" onClick={() => setIsLangMenuShown(!isLangMenuShown)} type="button">{getLanguageName(language)} <span className="triangle">▾</span></button>
         <span className={`list${isLangMenuShown ? ' is-shown' : ''}`}>
@@ -103,8 +113,9 @@ const HeaderDesktop = ({ language, hasLanguage, setLanguage }) => {
 const HeaderMobile = ({ language, hasLanguage, setLanguage }) => {
   const [isOpen, setIsOpen] = useState(false);
   const toggleIsOpen = useCallback(() => setIsOpen(!isOpen), [isOpen, setIsOpen]);
-  const [isLangMenuShown, setIsLangMenuShown] = useState(false)
-  const [isConferencesMenuShown, setIsConferencesMenuShown] = useState(false)
+  const [isLangMenuShown, setIsLangMenuShown] = useState(false);
+  const [isConferencesMenuShown, setIsConferencesMenuShown] = useState(false);
+  const [isAboutMenuShown, setIsAboutMenuShown] = useState(false);
 
   const setLang = useCallback(lang => {
     setLanguage(lang)
@@ -155,6 +166,16 @@ const HeaderMobile = ({ language, hasLanguage, setLanguage }) => {
           </span>
           <a href="/slack">Slack</a>
           <Link to="/contribute">Contribute</Link>
+          <span className="languageSelect about">
+            <button className="button" onClick={() => setIsAboutMenuShown(!isAboutMenuShown)} type="button">About <span className="triangle">▾</span></button>
+            <span className={`list${isAboutMenuShown ? ' is-shown' : ''}`}>
+              <Link className="link" to="/members">Members</Link>
+              <Link className="link" to="/governing-board">Governing board</Link>
+              <Link className="link" to="/steering-committee">eBPF Steering Committee</Link>
+              <Link className="link" to="/charter">Charter</Link>
+              <Link className="link" to="/contribute">How to Contribute</Link>
+            </span>
+          </span>
           {hasLanguage && <span className="languageSelect">
             <button className="button" onClick={() => setIsLangMenuShown(!isLangMenuShown)} type="button">{getLanguageName(language)} <span className="triangle">▾</span></button>
             <span className={`list${isLangMenuShown ? ' is-shown' : ''}`}>


### PR DESCRIPTION
This pull request adds new menu items in Header & Mobile menus:
- Members
- Charter

Temporarily hide pages below in the menu:
- Governing Board
- eBPF Steering Committee

 **Screenshots**
Desktop:
![image](https://user-images.githubusercontent.com/48465000/128880776-6ddbf5e7-24b7-4ba1-8f04-ddf6e6f7cb4a.png)

Mobile: 
![image](https://user-images.githubusercontent.com/48465000/128880555-37425711-e763-456a-ba15-b21d1651d632.png)

