### PR TITLE
Fix: change the menu item in header & mobile menus

### DIFF
--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -86,9 +86,7 @@ const HeaderDesktop = ({ language, hasLanguage, setLanguage }) => {
       <span className="languageSelect about">
         <button className="button" onClick={() => setIsAboutMenuShown(!isAboutMenuShown)} type="button">About <span className="triangle">▾</span></button>
         <span className={`list${isAboutMenuShown ? ' is-shown' : ''}`}>
-          <Link className="link" to="/members">Members</Link>
-          {/* <Link className="link" to="/governing-board">Governing board</Link>
-          <Link className="link" to="/steering-committee">eBPF Steering Committee</Link> */}
+          <Link className="link" to="/foundation">Governance</Link>
           <Link className="link" to="/charter">Charter</Link>
           <Link className="link" to="/contribute">How to Contribute</Link>
         </span>
@@ -168,9 +166,7 @@ const HeaderMobile = ({ language, hasLanguage, setLanguage }) => {
           <span className="languageSelect about">
             <button className="button" onClick={() => setIsAboutMenuShown(!isAboutMenuShown)} type="button">About <span className="triangle">▾</span></button>
             <span className={`list${isAboutMenuShown ? ' is-shown' : ''}`}>
-              <Link className="link" to="/members">Members</Link>
-              {/* <Link className="link" to="/governing-board">Governing board</Link>
-              <Link className="link" to="/steering-committee">eBPF Steering Committee</Link> */}
+              <Link className="link" to="/foundation">Governance</Link>
               <Link className="link" to="/charter">Charter</Link>
               <Link className="link" to="/contribute">How to Contribute</Link>
             </span>

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,4 +1,5 @@
 # Redirect all pages under /news/ to the equivalent path under /blog/
 /news/* /blog/:splat
+/members /foundation
 # It should be at the end of the file in order to keep redirects on top of it working
 /* https://ebpf-summit-2021.netlify.app/:splat 200


### PR DESCRIPTION
This pull request changes the menu item `Members` to `Governance` and slug `/members` to `/foundation` in Header and Mobile menus. 
Link for testing: https://deploy-preview-145--ebpfio.netlify.app/

**Screenshots**
![image](https://user-images.githubusercontent.com/48465000/132680748-fa6f72c3-f313-4b0e-83d7-264fd95b13af.png)
